### PR TITLE
Fix state machine errors

### DIFF
--- a/artifacts/scripts/AnimeUtopia/process_content/lambda_function.py
+++ b/artifacts/scripts/AnimeUtopia/process_content/lambda_function.py
@@ -187,12 +187,12 @@ def lambda_handler(event, context):
     """
     post = event.get("post", {})
     full_title = post.get("title", "")
+    if not full_title:
+        return {"status": "error", "error": "No title provided in post."}
 
-    _ = fetch_anilist_titles_and_image(full_title)
+    anime_titles, image_path = fetch_anilist_titles_and_image(full_title)
 
-    core_title, description = extract_core_title_and_description(full_title, [])
-
-    anime_titles, image_path = fetch_anilist_titles_and_image(core_title)
+    core_title, description = extract_core_title_and_description(full_title, anime_titles)
 
     post["title"] = core_title
     post["description"] = description if description else post.get("description", "")

--- a/artifacts/scripts/AnimeUtopia/save_video/lambda_function.py
+++ b/artifacts/scripts/AnimeUtopia/save_video/lambda_function.py
@@ -5,11 +5,11 @@ import boto3
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-
 def lambda_handler(event, context):
     """
     Trigger the Windows EC2 instance via SSM to upload the rendered video
-    (anime_post.mp4) to the designated S3 bucket.
+    (anime_post.mp4) and the After Effects project file (anime_template_exported.aep)
+    to the designated S3 bucket. The project file is stored under the 'exports/' prefix.
     """
     instance_id = os.environ.get("INSTANCE_ID")
     target_bucket = os.environ.get("TARGET_BUCKET")
@@ -26,7 +26,8 @@ def lambda_handler(event, context):
 
     ssm = boto3.client("ssm")
     commands = [
-        f'aws s3 cp "anime_post.mp4" "s3://{target_bucket}"'
+        f'aws s3 cp "anime_post.mp4" "s3://{target_bucket}/anime_post.mp4"',
+        f'aws s3 cp "anime_template_exported.aep" "s3://{target_bucket}/exports/anime_template_exported.aep"'
     ]
 
     try:

--- a/lambda.tf
+++ b/lambda.tf
@@ -43,6 +43,26 @@ resource "aws_iam_policy" "ec2_control_policy" {
   })
 }
 
+resource "aws_iam_policy" "ssm_send_command_policy" {
+  name        = "anime_ssm_send_command_policy"
+  description = "Policy to allow Lambda functions to send SSM commands on EC2 instances"
+  policy      = jsonencode({
+    Version   : "2012-10-17",
+    Statement : [
+      {
+        Effect   : "Allow",
+        Action   : "ssm:SendCommand",
+        Resource = "*"  // You could scope this further to your EC2 instance if needed.
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_ssm_send_command_policy" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.ssm_send_command_policy.arn
+}
+
 resource "aws_iam_role_policy_attachment" "attach_ec2_control_policy" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = aws_iam_policy.ec2_control_policy.arn


### PR DESCRIPTION
"No 'post' data found in event."

"error": "Failed to send SSM command: An error occurred (AccessDeniedException) when calling the SendCommand operation: User: arn:aws:sts::481665084477:assumed-role/anime_lambda_role/save_video is not authorized to perform: ssm:SendCommand on resource: arn:aws:ec2:us-east-2:481665084477:instance/i-022e9bb5447996955 because no identity-based policy allows the ssm:SendCommand action"

"Failed to upload project file: [Errno 2] No such file or directory: 'anime_template_exported.aep'"